### PR TITLE
Feat: improve masquerade info

### DIFF
--- a/chrome/background/background.ts
+++ b/chrome/background/background.ts
@@ -85,7 +85,8 @@ class BackgroundHandler {
       await this.getCurrentUser(url as string) :
       {
         currentUser: {
-          name: this.state.metadata && this.state.metadata.name || '',
+          name: this.state.metadata?.name || '',
+          simpleName: '',
           type: 'not_logged_in' as 'not_logged_in',
         },
         isMasquerading: false,
@@ -225,6 +226,7 @@ class BackgroundHandler {
       return {
         currentUser: {
           name: 'Not logged in',
+          simpleName: '',
           type: 'not_logged_in'
         },
         isMasquerading: false
@@ -252,16 +254,18 @@ class BackgroundHandler {
       return {
         currentUser: {
           type,
-          name: fullName
+          name: fullName,
+          simpleName: name,
         },
         isMasquerading
       }
     } catch (e) {
       // Not logged in returns 401
-      if (e.response && e.response.status === 401) {
+      if (e.response?.status === 401) {
         return {
           currentUser: {
             name: 'Not logged in',
+            simpleName: '',
             type: 'not_logged_in'
           },
           isMasquerading: false
@@ -283,7 +287,7 @@ class BackgroundHandler {
         name
       }, resolve);
     });
-    return cookie && cookie.value || null;
+    return cookie?.value || null;
   }
 }
 

--- a/chrome/background/background.ts
+++ b/chrome/background/background.ts
@@ -110,13 +110,14 @@ class BackgroundHandler {
   }
 
   public async sendReport(report: Report): Promise<void> {
-    // TODO error handling
     this.updateState({
       ...this.state,
       submitStatus: SubmitStatus.PENDING,
     });
     try {
+      console.info('Submitting report:', report);
       await axios.post('https://ingfo0ccaa.execute-api.eu-west-2.amazonaws.com/dev/report', report);
+
       this.updateState({
         ...this.state,
         submitStatus: SubmitStatus.SUCCESS,
@@ -213,13 +214,9 @@ class BackgroundHandler {
     const [
       token,
       userId,
-      staffMasqueraderToken,
-      staffMasqueraderId
     ] = await Promise.all([
       this.getCookie(host, 'token'),
       this.getCookie(host, 'userId'),
-      this.getCookie(host, 'staffMasqueraderToken'),
-      this.getCookie(host, 'staffMasqueraderId'),
     ]);
 
     console.log('Got tokens?', token, userId);
@@ -238,10 +235,6 @@ class BackgroundHandler {
       'citypantry-authtoken': token,
       'citypantry-userid': userId
     };
-    if (staffMasqueraderId && staffMasqueraderToken) {
-      headers['citypantry-staffmasqueraderid'] = staffMasqueraderId;
-      headers['citypantry-staffmasqueradertoken'] = staffMasqueraderToken;
-    }
 
     try {
       const response = await axios.get(apiUrl, { headers });

--- a/chrome/background/background.ts
+++ b/chrome/background/background.ts
@@ -248,7 +248,7 @@ class BackgroundHandler {
           'user';
 
       const fullName = name + (type === 'customer' ? ` (${response.data.customer.companyName ? ('Customer: ' + response.data.customer.companyName) : 'Customer' })`:
-          type === 'vendor' ? ` (Vendor)` : ''
+          type === 'vendor' ? ` (Vendor: ${response.data.vendor.name})` : ''
       );
 
       return {

--- a/chrome/dist/manifest.json
+++ b/chrome/dist/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "City Pantry Error Reporting",
   "short_name": "CP Error Reporting",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "manifest_version": 2,
   "description": "Easily report errors on citypantry.com",
   "homepage_url": "https://slack.com/app_redirect?channel=C0KDSMAMV",

--- a/chrome/popup/form.tsx
+++ b/chrome/popup/form.tsx
@@ -30,12 +30,12 @@ export class Form extends React.Component<FormProps, FormState> {
       name: props.metadata.name || '',
       summary: '',
       description: '',
-      affectedPeople: '',
+      affectedPeople: props.snapshot?.currentUser?.simpleName || '',
       incidentSize: IncidentSize.STAFF_ONLY,
       url: props.snapshot.url || '',
       time: props.snapshot.time || '',
       stepsToReproduce: '',
-      currentUser: props.snapshot.currentUser && props.snapshot.currentUser.name || '',
+      currentUser: props.snapshot.currentUser?.name || '',
       isMasquerading: props.snapshot.isMasquerading,
       consoleErrors: props.snapshot.debugData || '',
       screenshot: props.snapshot.screenshot,
@@ -213,7 +213,7 @@ export class Form extends React.Component<FormProps, FormState> {
             Affected People
           </label>
           <p class="form-group__sub-label">
-            Who is affected by this bug?
+            Who is affected by this bug? Please provide customer, vendor or user names.
           </p>
           <input
             className={this.getClassName('affectedPeople')}

--- a/chrome/shared/state.interface.ts
+++ b/chrome/shared/state.interface.ts
@@ -19,6 +19,7 @@ export interface Snapshot {
 export interface UserSnapshot {
   type: 'user' | 'customer' | 'vendor' | 'not_logged_in';
   name: string;
+  simpleName: string | ''; // Can be '' if not logged in
 }
 
 export enum SubmitStatus {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "serverless-webpack": "^5.1.0",
     "style-loader": "^0.20.3",
     "ts-loader": "4",
-    "typescript": "^3.2.4",
+    "typescript": "^3.9.3",
     "webpack": "^4.39.3",
     "webpack-cli": "^2.0.12"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "citypantry-error-plugin",
   "author": "Lewis Wilcock <lewis.wilcock@gmail.com>, Paul Lessing <paul@paullessing.com>",
   "license": "MIT",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Error reporting chrome plugin for citypantry.com",
   "main": "handler.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6840,10 +6840,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+typescript@^3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 unbzip2-stream@^1.0.9:
   version "1.3.3"


### PR DESCRIPTION
Features in this PR:

* TS Upgrade
* No longer use the old `staffMasquerader*` tokens (they are redundant)
* Provide the vendor name in the "Masquerading as" message (e.g. `Masquerading as Stu Sunderland (Vendor: Stu's Stews)`)
* Default the "Affected people" field to the current user name