### PR TITLE
feat: added empty dev notes field to jira description

### DIFF
--- a/backend/handlers/report.ts
+++ b/backend/handlers/report.ts
@@ -139,6 +139,9 @@ function createJiraDescription(report: Report, screenshotUrl: string | null, dat
     content: [
       Doc.p(Doc.text(report.description)),
       Doc.p(
+        Doc.text('Dev notes:', 'strong'), Doc.br,
+      ),
+      Doc.p(
         Doc.text('User: ', 'strong'), Doc.text((report.isMasquerading ? 'Masquerading as ' : '') + report.currentUser), Doc.br,
         Doc.text('URL: ', 'strong'), Doc.link(report.url), Doc.br,
         Doc.text('Time: ', 'strong'), Doc.text(report.time),


### PR DESCRIPTION
Adds a "Dev notes:" field with empty space right below bug description.

This should encourage investigating devs to add their notes, and make it easier to spot and read notes that other devs have left.

![image](https://user-images.githubusercontent.com/14551750/114404990-85681780-9ba6-11eb-93a5-9eb160f04f11.png)


<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>